### PR TITLE
Update sample plugin for use with TSQLLint.Common 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains a sample solution and project which builds a TSQLLint plugin.
 
 ## Usage
 
-Build the plugin and pu
+Build the plugin
 
 ```
 dotnet build tsqllint-sample-plugin.sln --output /tmp/tsqllint-plugin

--- a/tsqllint-sample-plugin.sln
+++ b/tsqllint-sample-plugin.sln
@@ -1,0 +1,32 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tsqllint-sample-plugin", "tsqllint-sample-plugin\tsqllint-sample-plugin.csproj", "{E52E49AC-EB73-42F7-ABEA-CCFCCBE2B7F1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BC95CB10-89E9-49B2-8909-406183FE04B1}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E52E49AC-EB73-42F7-ABEA-CCFCCBE2B7F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E52E49AC-EB73-42F7-ABEA-CCFCCBE2B7F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E52E49AC-EB73-42F7-ABEA-CCFCCBE2B7F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E52E49AC-EB73-42F7-ABEA-CCFCCBE2B7F1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CDAA2FD6-5D3E-4833-A141-C0376525B779}
+	EndGlobalSection
+EndGlobal

--- a/tsqllint-sample-plugin/SamplePlugin.cs
+++ b/tsqllint-sample-plugin/SamplePlugin.cs
@@ -1,17 +1,20 @@
 ﻿using System;
-using TSQLLint.Common;
+using System.Collections.Generic;
 using System.IO;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+using TSQLLint.Common;
 
-namespace TSQLLint.Tests.UnitTests.PluginHandler
+namespace TSQLLint_Sample_Plugin
 {
     public class SamplePlugin : IPlugin
     {
+        // This method is required but can be a no-op if using the GetRules method to parse code through the plugin's rules.
         public void PerformAction(IPluginContext context, IReporter reporter)
         {
             string line;
             var lineNumber = 0;
 
-			var reader = new StreamReader(File.OpenRead(context.FilePath));
+            var reader = new StreamReader(File.OpenRead(context.FilePath));
 
             while ((line = reader.ReadLine()) != null)
             {
@@ -26,13 +29,19 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
                     RuleViolationSeverity.Warning));
             }
         }
+
+        // Starting with TSQLLint.Common version 3.3.0, this method can be used to return rules to be used by the TSQLLint parser.
+        public IDictionary<string, ISqlLintRule> GetRules() => new Dictionary<string, ISqlLintRule>
+        {
+            ["sample-plugin-rule"] = new SampleRule((Action<string, string, int, int>)null)
+        };
     }
 
     public class SampleRuleViolation : IRuleViolation
     {
-        public int Column { get; private set; }
+        public int Column { get; set; }
         public string FileName { get; private set; }
-        public int Line { get; private set; }
+        public int Line { get; set; }
         public string RuleName { get; private set; }
         public RuleViolationSeverity Severity { get; private set; }
         public string Text { get; private set; }
@@ -45,6 +54,35 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             Line = lineNumber;
             Column = column;
             Severity = ruleViolationSeverity;
+        }
+    }
+
+    public class SampleRule : TSqlFragmentVisitor, ISqlLintRule
+    {
+        protected readonly Action<string, string, int, int> ErrorCallback;
+
+        public SampleRule(Action<string, string, int, int> errorCallback)
+        {
+            ErrorCallback = errorCallback;
+        }
+
+        public string RULE_NAME => "sample-plugin-rule";
+        public string RULE_TEXT => "Sample plugin rule message text";
+        public RuleViolationSeverity RULE_SEVERITY => RuleViolationSeverity.Warning;
+
+        public override void Visit(TSqlScript node)
+        {
+            var line = 0;
+            var column = 0;
+
+            // Logic for testing TSQL code for rule goes here.
+
+            ErrorCallback(RULE_NAME, RULE_TEXT, line, column);
+        }
+
+        public void FixViolation(List<string> fileLines, IRuleViolation ruleViolation, FileLineActions actions)
+        {
+            // Logic for fixing rule violation goes here.
         }
     }
 }

--- a/tsqllint-sample-plugin/tsqllint-sample-plugin.csproj
+++ b/tsqllint-sample-plugin/tsqllint-sample-plugin.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>tsqllint_sample_plugin</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="TSQLLint.Common" Version="3.0.0" />
+      <PackageReference Include="TSQLLint.Common" Version="3.3.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Updated sample plugin to include `IPlugin.GetRules` method implementation.
- Added solution file since it is mentioned in the readme file.
- Updated `TSQLLint.Common` to version 3.3.0.
- Made sample project use .NET 6.0.
- Will be relevant with next version of TSQLLint after https://github.com/tsqllint/tsqllint/pull/302 is merged.