### PR TITLE
fix: Ensure StreamReader is closed after use with 'using' keyword

### DIFF
--- a/tsqllint-sample-plugin/SamplePlugin.cs
+++ b/tsqllint-sample-plugin/SamplePlugin.cs
@@ -11,7 +11,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             string line;
             var lineNumber = 0;
 
-			var reader = new StreamReader(File.OpenRead(context.FilePath));
+            using var reader = new StreamReader(File.OpenRead(context.FilePath));
 
             while ((line = reader.ReadLine()) != null)
             {


### PR DESCRIPTION
When the file stream is left open when run on Windows (in particular) and any other rules attempt to fix the SQL file, this will trigger a file access violation.

Add a `using` to ensure the file stream is closed after use.
